### PR TITLE
update from hashlib

### DIFF
--- a/oss/oss_util.py
+++ b/oss/oss_util.py
@@ -11,7 +11,7 @@ import hmac
 import time
 from hashlib import sha1 as sha
 import os
-import md5
+from hashlib import md5
 import StringIO
 from oss_xml_handler import *
 from threading import Thread


### PR DESCRIPTION
md5 is Deprecation in python 2.6
